### PR TITLE
Adicao do cabecalho para funcionamento em python3 e UTF8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from setuptools import setup, find_packages
+
 setup(
     name="django-br-documents",
     version="0.0.1",
@@ -23,5 +27,5 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
-    install_requires=["Django>=1.4.3","br_documents"],
+    install_requires=["Django>=1.4.3","br_documents"]
 )


### PR DESCRIPTION
Quando fui executar o instalador no meu Archlinux, obtive um problema ao executar o setup.py. A solução foi adicionar esse cabecalho.
